### PR TITLE
Use PRIu32 define in printf to prevent compiler warning

### DIFF
--- a/dns.c
+++ b/dns.c
@@ -161,7 +161,7 @@ parse_answer(uint8_t *buffer, int len, uint8_t **b, int *rlen)
 		return 0;
 	}
 
-	printf("%s %s %d\n", name, ipbuf, a->ttl);
+	printf("%s %s %" PRIu32 "\n", name, ipbuf, a->ttl);
 
 	return 0;
 }

--- a/dns.h
+++ b/dns.h
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 #include <netinet/ip.h>
 #include <sys/socket.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
Signed-off-by: Michael Heimpold <mhei@heimpold.de>