### PR TITLE
ubus: fix qosify add_dns_host call

### DIFF
--- a/main.c
+++ b/main.c
@@ -197,7 +197,7 @@ ubus_notify_qosify(char *name, char *address, int type, int ttl)
 	blobmsg_add_string(&b, "address", address);
         blobmsg_add_u32(&b, "ttl", ttl);
 
-	ubus_invoke(&conn.ctx, qosify, "add_dns_host", NULL, NULL, NULL, 200);
+	ubus_invoke(&conn.ctx, qosify, "add_dns_host", b.head, NULL, NULL, 200);
 }
 
 static void


### PR DESCRIPTION
The ubus call to the qosify add_dns_host method contains no data.